### PR TITLE
feat: ユーザー登録機能を改善し、バリデーションメッセージを追加

### DIFF
--- a/frontend/src/RegisterForm.js
+++ b/frontend/src/RegisterForm.js
@@ -17,6 +17,7 @@ import { Visibility, VisibilityOff, Email, Lock, Person } from '@mui/icons-mater
 import { useForm, Controller } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
+import { authAPI } from './utils/api';
 
 // バリデーションスキーマ
 const registerSchema = yup.object({
@@ -69,22 +70,26 @@ export default function RegisterForm({ onRegister, onSwitchToLogin }) {
     setRegisterError('');
     
     try {
-      // TODO: API呼び出し実装
-      console.log('新規登録試行:', data);
-      
-      // 仮の登録処理（実際にはAPI呼び出し）
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // API呼び出しで新規登録
+      const response = await authAPI.register(data.name, data.email, data.password);
       
       if (onRegister) {
         onRegister({
-          name: data.name,
-          email: data.email,
-          password: data.password
+          id: response.user.id,
+          name: response.user.name,
+          email: response.user.email,
+          role: response.user.role
         });
       }
     } catch (error) {
-      if (error.code === 'EMAIL_ALREADY_EXISTS') {
+      console.error('Registration error:', error);
+      
+      if (error.message.includes('EMAIL_ALREADY_EXISTS')) {
         setRegisterError('このメールアドレスは既に登録されています');
+      } else if (error.message.includes('NAME_ALREADY_EXISTS')) {
+        setRegisterError('このユーザー名は既に使用されています');
+      } else if (error.message.includes('Validation failed')) {
+        setRegisterError('入力内容に不備があります。もう一度確認してください');
       } else {
         setRegisterError('登録中にエラーが発生しました。もう一度お試しください');
       }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -48,10 +48,10 @@ export const authAPI = {
   },
 
   // 新規登録
-  register: async (username, email, password, role = 'user') => {
+  register: async (name, email, password, role = 'user') => {
     return apiRequest('/api/auth/register', {
       method: 'POST',
-      body: JSON.stringify({ username, email, password, role }),
+      body: JSON.stringify({ name, email, password, role }),
     });
   },
 

--- a/web/src/models/User.js
+++ b/web/src/models/User.js
@@ -5,7 +5,7 @@ import database from '../config/database.js';
 class User {
   constructor(data) {
     this.id = data.id;
-    this.username = data.username || data.name;
+    this.name = data.name || data.username;
     this.email = data.email;
     this.role = data.role;
     this.createdAt = data.created_at;
@@ -15,7 +15,7 @@ class User {
   // ユーザーをIDで取得
   static async findById(userId) {
     const result = await database.query(
-      'SELECT id, name as username, email, role, created_at, updated_at FROM users WHERE id = $1',
+      'SELECT id, name, email, role, created_at, updated_at FROM users WHERE id = $1',
       [userId]
     );
     return result.rows[0] ? new User(result.rows[0]) : null;
@@ -24,23 +24,23 @@ class User {
   // ユーザーをメールアドレスで取得
   static async findByEmail(email) {
     const result = await database.query(
-      'SELECT id, name as username, email, password_hash, role, created_at, updated_at FROM users WHERE email = $1',
+      'SELECT id, name, email, password_hash, role, created_at, updated_at FROM users WHERE email = $1',
       [email]
     );
     return result.rows[0] || null;
   }
 
-  // ユーザーをユーザー名で取得
-  static async findByUsername(username) {
+  // ユーザーを名前で取得
+  static async findByName(name) {
     const result = await database.query(
-      'SELECT id, name as username, email, role, created_at, updated_at FROM users WHERE name = $1',
-      [username]
+      'SELECT id, name, email, role, created_at, updated_at FROM users WHERE name = $1',
+      [name]
     );
     return result.rows[0] ? new User(result.rows[0]) : null;
   }
 
   // 新しいユーザーを作成
-  static async create({ username, email, password, role = 'user' }) {
+  static async create({ name, email, password, role = 'user' }) {
     // メールアドレスの重複チェック
     const existingEmail = await this.findByEmail(email);
     if (existingEmail) {
@@ -48,9 +48,9 @@ class User {
     }
 
     // ユーザー名の重複チェック
-    const existingUsername = await this.findByUsername(username);
-    if (existingUsername) {
-      throw new Error('Username already exists');
+    const existingName = await this.findByName(name);
+    if (existingName) {
+      throw new Error('Name already exists');
     }
 
     // パスワードのハッシュ化
@@ -59,8 +59,8 @@ class User {
 
     // ユーザーの作成
     const result = await database.query(
-      'INSERT INTO users (name, email, password_hash, role) VALUES ($1, $2, $3, $4) RETURNING id, name as username, email, role, created_at',
-      [username, email, hashedPassword, role]
+      'INSERT INTO users (name, email, password_hash, role) VALUES ($1, $2, $3, $4) RETURNING id, name, email, role, created_at',
+      [name, email, hashedPassword, role]
     );
 
     return new User(result.rows[0]);
@@ -108,7 +108,7 @@ class User {
   toJSON() {
     return {
       id: this.id,
-      username: this.username,
+      name: this.name,
       email: this.email,
       role: this.role,
       createdAt: this.createdAt,

--- a/web/src/routes/auth.js
+++ b/web/src/routes/auth.js
@@ -11,14 +11,14 @@ export default async function authRoutes(fastify, options) {
       if (error) {
         return reply.code(400).send({ 
           error: 'Validation failed', 
-          details: error.details[0].message 
+          message: error.details[0].message 
         });
       }
 
-      const { username, email, password, role } = value;
+      const { name, email, password, role = 'user' } = value;
 
       // ユーザーの作成
-      const newUser = await User.create({ username, email, password, role });
+      const newUser = await User.create({ name, email, password, role });
 
       // JWTトークンの生成
       const token = fastify.jwt.sign({ 
@@ -37,20 +37,34 @@ export default async function authRoutes(fastify, options) {
 
       return reply.code(201).send({
         message: 'User registered successfully',
-        user: newUser.toJSON()
+        user: {
+          id: newUser.id,
+          name: newUser.name,
+          email: newUser.email,
+          role: newUser.role
+        }
       });
 
     } catch (error) {
       fastify.log.error(error);
       
       if (error.message === 'Email already exists') {
-        return reply.code(409).send({ error: 'Email already exists' });
+        return reply.code(409).send({ 
+          error: 'EMAIL_ALREADY_EXISTS',
+          message: 'このメールアドレスは既に登録されています' 
+        });
       }
-      if (error.message === 'Username already exists') {
-        return reply.code(409).send({ error: 'Username already exists' });
+      if (error.message === 'Name already exists') {
+        return reply.code(409).send({ 
+          error: 'NAME_ALREADY_EXISTS',
+          message: 'このユーザー名は既に使用されています' 
+        });
       }
       
-      return reply.code(500).send({ error: 'Internal server error' });
+      return reply.code(500).send({ 
+        error: 'INTERNAL_SERVER_ERROR',
+        message: '登録中にエラーが発生しました。もう一度お試しください' 
+      });
     }
   });
 

--- a/web/src/schemas/validation.js
+++ b/web/src/schemas/validation.js
@@ -8,9 +8,20 @@ export const loginSchema = Joi.object({
 });
 
 export const registerSchema = Joi.object({
-  username: Joi.string().min(3).max(50).required(),
-  email: Joi.string().email().required(),
-  password: Joi.string().min(6).required(),
+  name: Joi.string().min(2).max(64).required().messages({
+    'string.min': 'ユーザー名は2文字以上で入力してください',
+    'string.max': 'ユーザー名は64文字以下で入力してください',
+    'any.required': 'ユーザー名は必須です'
+  }),
+  email: Joi.string().email().required().messages({
+    'string.email': '正しいメールアドレスを入力してください',
+    'any.required': 'メールアドレスは必須です'
+  }),
+  password: Joi.string().min(8).pattern(/^(?=.*[a-zA-Z])(?=.*[0-9])/).required().messages({
+    'string.min': 'パスワードは8文字以上で入力してください',
+    'string.pattern.base': 'パスワードは英数字を含む必要があります',
+    'any.required': 'パスワードは必須です'
+  }),
   role: Joi.string().valid('user', 'admin').default('user')
 });
 


### PR DESCRIPTION
This pull request refactors the user registration flow to consistently use the field name `name` instead of `username` across the frontend and backend. It also improves validation and error handling for user registration, ensuring clearer error messages and better API consistency.

**Backend changes:**

*User model and database:*
- Replaced all usage of `username` with `name` in the `User` model, queries, and returned JSON objects to standardize the field naming. [[1]](diffhunk://#diff-537ef08771aca4a1a1bf1cb11772a5438acc4318151ff356727d2ee70224c13bL8-R8) [[2]](diffhunk://#diff-537ef08771aca4a1a1bf1cb11772a5438acc4318151ff356727d2ee70224c13bL18-R18) [[3]](diffhunk://#diff-537ef08771aca4a1a1bf1cb11772a5438acc4318151ff356727d2ee70224c13bL27-R53) [[4]](diffhunk://#diff-537ef08771aca4a1a1bf1cb11772a5438acc4318151ff356727d2ee70224c13bL62-R63) [[5]](diffhunk://#diff-537ef08771aca4a1a1bf1cb11772a5438acc4318151ff356727d2ee70224c13bL111-R111)

*Validation and error handling:*
- Updated the registration validation schema to use `name` (with improved messages and stricter password requirements), and removed `username`.
- Enhanced error responses in the registration API: now returns specific error codes (`EMAIL_ALREADY_EXISTS`, `NAME_ALREADY_EXISTS`, etc.) and user-friendly messages for different failure scenarios. [[1]](diffhunk://#diff-8d05b4707b4bd917bbff6a2d6a852ece9e1a86590f932262febb4eb36b53dfbbL14-R21) [[2]](diffhunk://#diff-8d05b4707b4bd917bbff6a2d6a852ece9e1a86590f932262febb4eb36b53dfbbL40-R67)

**Frontend changes:**

*API and registration form:*
- Updated the frontend registration API and form to use `name` instead of `username`, and to handle new error codes/messages from the backend. [[1]](diffhunk://#diff-a05233cdf370b58c88157d7742823625e5a8f9c72f6dd8ba07908c7e306d5b22R20) [[2]](diffhunk://#diff-b0978257b7de4652e3a66018064ffed7b3cfe833b8564362c7688a33f60e53bdL51-R54) [[3]](diffhunk://#diff-a05233cdf370b58c88157d7742823625e5a8f9c72f6dd8ba07908c7e306d5b22L72-R92)